### PR TITLE
Replace GPG key ID with current one

### DIFF
--- a/Dockerfile.shiny
+++ b/Dockerfile.shiny
@@ -8,7 +8,7 @@ RUN apt-get update; \
         software-properties-common \
         build-essential; \
     add-apt-repository "deb http://cran.rstudio.com/bin/linux/ubuntu trusty/"; \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9; \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9; \
     apt-get update; \
     apt-get install -y r-base; \
     apt-get autoremove -y; \


### PR DESCRIPTION
… from RStudio site: https://cran.rstudio.com/bin/linux/ubuntu/README.html#secure-apt

fixes #8 